### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,5 +4,5 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.1.6
+            - uses: actions/checkout@v4.1.7
             - uses: chartboost/ruff-action@v1

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -6,3 +6,5 @@ jobs:
         steps:
             - uses: actions/checkout@v4.1.7
             - uses: chartboost/ruff-action@v1
+              with:
+                src: './src'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,13 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@main
+            - uses: actions/checkout@v4.1.7
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@main
+              uses: actions/setup-python@v5.1.1
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@main
+              uses: actions/cache@v4.0.2
               with:
                   # This path is specific to Ubuntu
                   path:
@@ -45,7 +45,7 @@ jobs:
                   make test
                   coverage xml
             - name: Run codacy-coverage-reporter
-              uses: codacy/codacy-coverage-reporter-action@v1
+              uses: codacy/codacy-coverage-reporter-action@v1.3.0
               with:
                   project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
                   coverage-reports: coverage.xml

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,9 +12,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@main
+            - uses: actions/checkout@v4.1.7
             - name: Set up Python
-              uses: actions/setup-python@main
+              uses: actions/setup-python@v5.1.1
               with:
                   python-version: "3.x"
             - name: Install dependencies
@@ -33,6 +33,6 @@ jobs:
                   --outdir dist/
                   .
             - name: Publish distribution package to PyPI
-              uses: pypa/gh-action-pypi-publish@master
+              uses: pypa/gh-action-pypi-publish@v1.9.0
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.1.7](https://github.com/actions/checkout/releases/tag/v4.1.7)** on 2024-06-12T19:05:21Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.9.0](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.9.0)** on 2024-06-16T19:24:22Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.1.1](https://github.com/actions/setup-python/releases/tag/v5.1.1)** on 2024-07-10T14:00:28Z
* **[codacy/codacy-coverage-reporter-action](https://github.com/codacy/codacy-coverage-reporter-action)** published a new release **[v1.3.0](https://github.com/codacy/codacy-coverage-reporter-action/releases/tag/v1.3.0)** on 2022-01-19T14:07:50Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.0.2](https://github.com/actions/cache/releases/tag/v4.0.2)** on 2024-03-19T15:55:41Z
