### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,7 +12,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4.1.7
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5.1.1
+              uses: actions/setup-python@v5.2.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4.1.7
             - name: Set up Python
-              uses: actions/setup-python@v5.1.1
+              uses: actions/setup-python@v5.2.0
               with:
                   python-version: "3.x"
             - name: Install dependencies
@@ -33,6 +33,6 @@ jobs:
                   --outdir dist/
                   .
             - name: Publish distribution package to PyPI
-              uses: pypa/gh-action-pypi-publish@v1.9.0
+              uses: pypa/gh-action-pypi-publish@v1.10.2
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.2.0](https://github.com/actions/setup-python/releases/tag/v5.2.0)** on 2024-08-29T13:57:38Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.10.2](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.10.2)** on 2024-09-20T21:51:57Z
