### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,7 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.0
             - uses: chartboost/ruff-action@v1
               with:
                 src: './src'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,13 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.0
             - name: Set up Python ${{ matrix.python-version }}
               uses: actions/setup-python@v5.2.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@v4.0.2
+              uses: actions/cache@v4.1.0
               with:
                   # This path is specific to Ubuntu
                   path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,7 +12,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.0
             - name: Set up Python
               uses: actions/setup-python@v5.2.0
               with:
@@ -33,6 +33,6 @@ jobs:
                   --outdir dist/
                   .
             - name: Publish distribution package to PyPI
-              uses: pypa/gh-action-pypi-publish@v1.10.2
+              uses: pypa/gh-action-pypi-publish@v1.10.3
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.0
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.UPDATER_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.0](https://github.com/actions/checkout/releases/tag/v4.2.0)** on 2024-09-25T17:52:55Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.0](https://github.com/actions/cache/releases/tag/v4.1.0)** on 2024-10-04T21:01:47Z
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.10.3](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.10.3)** on 2024-10-04T01:37:27Z
