### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -4,7 +4,7 @@ jobs:
     ruff:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.2
             - uses: chartboost/ruff-action@v1
               with:
                 src: './src'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -10,13 +10,13 @@ jobs:
                 python-version: ["3.10", "3.11", "3.12"]
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.2
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5.2.0
+              uses: actions/setup-python@v5.3.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@v4.0.2
+              uses: actions/cache@v4.1.2
               with:
                   # This path is specific to Ubuntu
                   path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -12,9 +12,9 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.2
             - name: Set up Python
-              uses: actions/setup-python@v5.2.0
+              uses: actions/setup-python@v5.3.0
               with:
                   python-version: "3.x"
             - name: Install dependencies
@@ -33,6 +33,6 @@ jobs:
                   --outdir dist/
                   .
             - name: Publish distribution package to PyPI
-              uses: pypa/gh-action-pypi-publish@v1.10.2
+              uses: pypa/gh-action-pypi-publish@v1.12.2
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}

--- a/.github/workflows/updater.yaml
+++ b/.github/workflows/updater.yaml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
 
         steps:
-            - uses: actions/checkout@v4.1.7
+            - uses: actions/checkout@v4.2.2
               with:
                   # [Required] Access token with `workflow` scope.
                   token: ${{ secrets.UPDATER_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.12.2](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.2)** on 2024-11-06T23:09:52Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.3.0](https://github.com/actions/setup-python/releases/tag/v5.3.0)** on 2024-10-24T14:15:17Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.1.2](https://github.com/actions/cache/releases/tag/v4.1.2)** on 2024-10-22T13:08:44Z
* **[actions/checkout](https://github.com/actions/checkout)** published a new release **[v4.2.2](https://github.com/actions/checkout/releases/tag/v4.2.2)** on 2024-10-23T14:46:00Z
