### PR TITLE
Update GitHub Action Versions

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -12,11 +12,11 @@ jobs:
         steps:
             - uses: actions/checkout@v4.2.2
             - name: Set up Python ${{ matrix.python-version }}
-              uses: actions/setup-python@v5.3.0
+              uses: actions/setup-python@v5.4.0
               with:
                   python-version: ${{ matrix.python-version }}
             - name: Cache pip
-              uses: actions/cache@v4.2.0
+              uses: actions/cache@v4.2.2
               with:
                   # This path is specific to Ubuntu
                   path:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,7 +14,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4.2.2
             - name: Set up Python
-              uses: actions/setup-python@v5.3.0
+              uses: actions/setup-python@v5.4.0
               with:
                   python-version: "3.x"
             - name: Install dependencies
@@ -33,6 +33,6 @@ jobs:
                   --outdir dist/
                   .
             - name: Publish distribution package to PyPI
-              uses: pypa/gh-action-pypi-publish@v1.12.3
+              uses: pypa/gh-action-pypi-publish@v1.12.4
               with:
                   password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
### GitHub Actions Version Updates
* **[pypa/gh-action-pypi-publish](https://github.com/pypa/gh-action-pypi-publish)** published a new release **[v1.12.4](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.12.4)** on 2025-01-24T03:29:15Z
* **[actions/cache](https://github.com/actions/cache)** published a new release **[v4.2.2](https://github.com/actions/cache/releases/tag/v4.2.2)** on 2025-02-27T14:49:12Z
* **[actions/setup-python](https://github.com/actions/setup-python)** published a new release **[v5.4.0](https://github.com/actions/setup-python/releases/tag/v5.4.0)** on 2025-01-28T03:28:18Z
